### PR TITLE
Add requirement on document clarity

### DIFF
--- a/draft-ietf-ntp-ntpv5-requirements.md
+++ b/draft-ietf-ntp-ntpv5-requirements.md
@@ -209,6 +209,12 @@ applicable trust model. Downgrading attacks that could lead to an adversary
 disabling or removing encryption or authentication MUST NOT be possible in the
 design of the protocol.
 
+## Document language
+
+The specification document MUST clearly distinguish between normative and
+non-normative parts of the specification. Furthermore, any included code
+samples MUST be non-normative.
+
 # Non-requirements
 
 This section covers topics that are explicitly out of scope.


### PR DESCRIPTION
This suggestion is in response to some (in my view) issues regarding clarity of what is required by the NTPv4 specification, and what is merely implementation suggestions and hints.